### PR TITLE
Add long-term statistics endpoint (closes #2)

### DIFF
--- a/clawbridge/DOCS.md
+++ b/clawbridge/DOCS.md
@@ -59,6 +59,7 @@ All other domains (including `light`, `switch`, `climate`, `todo`, `calendar`, `
 | `POST` | `/api/services/{domain}/{service}` | Call a service (control = immediate; confirm = 202 queued) |
 | `GET` | `/api/context` | Full AI context: permissions, entities, annotations, constraints, schedules, services |
 | `GET` | `/api/history/period` | State history (proxy HA history API, filtered to exposed entities) |
+| `GET` | `/api/history/statistics` | Long-term statistics (proxy HA statistics API, filtered to exposed entities) |
 
 ### Legacy Endpoints
 

--- a/clawbridge/OPENCLAW_API.md
+++ b/clawbridge/OPENCLAW_API.md
@@ -166,7 +166,43 @@ Proxies to Home Assistant history API, filtered to exposed entities only.
 
 ---
 
-### 9. Confirmation Action Status
+### 9. Long-Term Statistics
+
+**GET** `/api/history/statistics`
+
+Proxies to Home Assistant long-term statistics API, filtered to exposed entities only. Use this for data analysis on aggregated historical data (means, min/max, sums, state changes).
+
+**Query parameters:**
+- `start_time` (optional): ISO 8601 start time (e.g., `2026-01-01T00:00:00`)
+- `end_time` (optional): ISO 8601 end time
+- `statistic_ids` (optional): Comma-separated entity IDs (e.g., `sensor.temperature,sensor.humidity`)
+- `period` (optional): Aggregation period — `5minute`, `hour` (default), `day`, `week`, or `month`
+
+**Response:**
+```json
+{
+  "sensor.temperature": [
+    {
+      "start": "2026-01-01T00:00:00+00:00",
+      "end": "2026-01-01T01:00:00+00:00",
+      "mean": 21.5,
+      "min": 20.1,
+      "max": 22.8,
+      "last_reset": null,
+      "state": null,
+      "sum": null
+    }
+  ]
+}
+```
+
+**Rate limit:** 10 requests/minute (shared with history endpoint).
+
+**Note:** Only entities that record long-term statistics (`state_class` attribute) will return data.
+
+---
+
+### 10. Confirmation Action Status
 
 **GET** `/api/actions/{action_id}`
 
@@ -181,7 +217,7 @@ Poll status of a confirmation action (for `confirm`-level entities).
 
 ---
 
-### 10. WebSocket
+### 11. WebSocket
 
 **GET** `/api/websocket`
 
@@ -197,7 +233,7 @@ WebSocket endpoint for real-time state changes.
 
 ---
 
-### 11. AI Context (Call This First)
+### 12. AI Context (Call This First)
 
 **GET** `/api/context`
 
@@ -235,7 +271,7 @@ Returns a complete summary of your permissions and capabilities in a single call
 
 ---
 
-### 12. Legacy Endpoints
+### 13. Legacy Endpoints
 
 **GET** `/api/ai-sensors`
 
@@ -458,6 +494,36 @@ if resp.status_code == 200:
             print(f"{change['entity_id']}: {change['state']} at {change['last_changed']}")
 ```
 
+### Querying Long-Term Statistics
+
+```python
+import requests
+from datetime import datetime, timedelta
+
+BASE_URL = "http://localhost:8100"
+HEADERS = {"Authorization": "Bearer cb_xxxx"}
+
+# Statistics for the last 30 days, aggregated by day
+end = datetime.utcnow()
+start = end - timedelta(days=30)
+
+params = {
+    "start_time": start.strftime("%Y-%m-%dT%H:%M:%S"),
+    "end_time": end.strftime("%Y-%m-%dT%H:%M:%S"),
+    "statistic_ids": "sensor.temperature,sensor.humidity",
+    "period": "day",
+}
+
+resp = requests.get(f"{BASE_URL}/api/history/statistics", headers=HEADERS, params=params)
+
+if resp.status_code == 200:
+    statistics = resp.json()
+    for entity_id, data_points in statistics.items():
+        print(f"\n{entity_id}:")
+        for point in data_points:
+            print(f"  {point['start']}: mean={point.get('mean')}, min={point.get('min')}, max={point.get('max')}")
+```
+
 ---
 
 ## Typical Session Flow
@@ -500,6 +566,7 @@ if resp.status_code == 200:
 | POST | `/api/services/{domain}/{service}` | Call service |
 | GET | `/api/constraints` | Parameter constraints |
 | GET | `/api/history/period/{timestamp}` | History (filtered) |
+| GET | `/api/history/statistics` | Long-term statistics (filtered) |
 | GET | `/api/actions/{action_id}` | Poll confirmation status |
 | GET | `/api/websocket` | WebSocket real-time updates |
 | GET | `/api/ai-sensors` | Legacy sensor format |

--- a/clawbridge/app/ha_client.py
+++ b/clawbridge/app/ha_client.py
@@ -410,6 +410,30 @@ class HAClient:
             logger.warning("Failed to fetch history: %s", e)
         return []
 
+    # ── Long-term statistics ─────────────────────
+
+    async def get_statistics(self, start_time, statistic_ids, end_time=None, period="hour"):
+        """Fetch long-term statistics from HA for specific entities.
+        Returns dict mapping statistic_id to list of aggregated data points.
+        """
+        try:
+            params = {"period": period}
+            if start_time:
+                params["start_time"] = start_time
+            if end_time:
+                params["end_time"] = end_time
+            if statistic_ids:
+                params["statistic_ids"] = ",".join(statistic_ids)
+
+            url = f"{HA_URL}/api/history/statistics"
+            async with self._session.get(url, params=params) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+                logger.warning("Failed to fetch statistics: HTTP %d", resp.status)
+        except Exception as e:
+            logger.warning("Failed to fetch statistics: %s", e)
+        return {}
+
     # ── Services ──────────────────────────────────
 
     async def get_services(self):

--- a/clawbridge/app/server.py
+++ b/clawbridge/app/server.py
@@ -975,6 +975,51 @@ async def ha_api_history(request):
     return web.json_response(history, headers=CORS_HEADERS)
 
 
+# ── Long-term statistics endpoint (public) ────────────────
+
+async def ha_api_statistics(request):
+    """GET /api/history/statistics - Proxy HA long-term statistics for exposed entities only."""
+    ip = _get_client_ip(request)
+    if not _check_ip_allowlist(ip):
+        return web.json_response({"message": "IP not allowed"}, status=403, headers=CORS_HEADERS)
+
+    # Stricter rate limit for statistics queries
+    if not _check_rate_limit(ip + "_history", 10):
+        return web.json_response(
+            {"message": "History rate limit exceeded (10/min)"}, status=429, headers=CORS_HEADERS
+        )
+
+    key_id, key_config = _check_api_key(request)
+    if key_id is None:
+        return web.json_response({"message": "Invalid API key"}, status=401, headers=CORS_HEADERS)
+
+    effective = _get_effective_entities(key_config)
+
+    start_time = request.query.get("start_time")
+    end_time = request.query.get("end_time")
+    period = request.query.get("period", "hour")
+
+    # Filter requested statistic_ids to only exposed ones
+    requested = request.query.get("statistic_ids", "")
+    if requested:
+        requested_ids = [e.strip() for e in requested.split(",")]
+        statistic_ids = [sid for sid in requested_ids if sid in effective]
+    else:
+        statistic_ids = list(effective.keys())
+
+    if not statistic_ids:
+        return web.json_response({}, headers=CORS_HEADERS)
+
+    # Cap to 20 entities per statistics query for performance
+    statistic_ids = statistic_ids[:20]
+
+    statistics = await ha_client.get_statistics(start_time, statistic_ids, end_time, period)
+
+    # Filter response to only include exposed entities
+    filtered = {k: v for k, v in statistics.items() if k in effective}
+    return web.json_response(filtered, headers=CORS_HEADERS)
+
+
 # ── Context endpoint (public) ────────────────
 
 async def ha_api_context(request):
@@ -1572,6 +1617,7 @@ def create_public_app():
     app.router.add_get("/api/context", ha_api_context)
     app.router.add_get("/api/constraints", ha_api_get_constraints)
     app.router.add_get("/api/history/period/{timestamp}", ha_api_history)
+    app.router.add_get("/api/history/statistics", ha_api_statistics)
     app.router.add_get("/api/actions/{action_id}", ha_api_action_status)
 
     # WebSocket


### PR DESCRIPTION
Expose HA's /api/history/statistics through ClawBridge so AI agents can query aggregated long-term data (mean, min, max, sum) for data analysis. The endpoint applies the same security controls as the existing history endpoint: IP allowlist, API key auth, rate limiting (10/min shared with history), entity filtering, and a 20-entity cap.

- ha_client.py: add get_statistics() method
- server.py: add ha_api_statistics() handler + route registration
- OPENCLAW_API.md: document new endpoint, params, response, and example
- DOCS.md: add statistics endpoint to REST endpoints table

https://claude.ai/code/session_01V1SYshAXUnXpMdmKr9o1wk